### PR TITLE
fix: resolve correct child segment on upload

### DIFF
--- a/src/pages/Upload/index.tsx
+++ b/src/pages/Upload/index.tsx
@@ -5,10 +5,6 @@ import {
   useNavigate,
   useOutletContext,
 } from 'react-router-dom';
-import UploadDefaultStep from './UploadDefaultStep';
-import UploadInProgresStep from './UploadInProgressStep';
-import UploadGuidelineStep from './UploadGuidelineStep';
-import UploadCautionStep from './UploadCautionStep';
 import { SecondaryTopbar } from '../../components/common/TopBar';
 import {
   ArrowBackDefaultIcon,

--- a/src/pages/Upload/index.tsx
+++ b/src/pages/Upload/index.tsx
@@ -23,21 +23,33 @@ type UploadContextType = {
   navigateToNextStep: () => void;
   navigateToHome: () => void;
 };
-type UploadLocationType = { pathname: UploadRoutes };
+
+// TODO move function to different file when it's used in common
+
+const getChlidSegment = (
+  pathname: string,
+  parentSegment: string,
+): UploadRoutes => {
+  const segments = pathname.split('/');
+  const endingSegment = segments.slice(-1)[0];
+  if (endingSegment === parentSegment) {
+    return '' as UploadRoutes.Default;
+  }
+  return endingSegment as UploadRoutes;
+};
 
 export default function Upload() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const segment = pathname.split('/upload').slice(-1)[0] as UploadRoutes;
 
+  const childSegment = getChlidSegment(pathname, 'upload');
   const [step, setStep] = useState<UploadRoutes>(UploadRoutes.Default);
 
   const navigateToHome = () => navigate('/');
 
   useEffect(() => {
-    console.log(segment);
-    setStep(segment);
-  }, [segment, setStep]);
+    setStep(childSegment);
+  }, [childSegment, setStep]);
 
   const navigateToNextStep = () => {
     if (step === UploadRoutes.Default) {


### PR DESCRIPTION
# Description

## 문제 상황

[문제 상황 디스코드 메시지](https://discord.com/channels/1170766777840574647/1212599384051683430/1212755243365048441)

## 원인 

path를 통하여 step 상태를 확인하는 과정에서 path가 `/upload` 로 default인 경우, step이 `upload` 가 되어서 다음 페이지로 정상적으로 넘어가지 않았습니다.

## 해결 방법

 `getChildSegment` 라는 함수를 만들어 관심사를 분리하고, 여기서 parentSegment와 endingSegment가 같은 경우(path가 `/upload` 인 경우) empty string을 반환하도록 만들었습니다.

