### PR TITLE
fix: render materials when undefined

### DIFF
--- a/src/pages/MaterialBox/index.tsx
+++ b/src/pages/MaterialBox/index.tsx
@@ -61,7 +61,7 @@ const MaterialBox = () => {
           {}
         </CardTitleWrapper>
         <CardsWrapper>
-          {materialsByState?.beforePay.map((material) => (
+          {materialsByState?.beforePay?.map((material) => (
             <HomeMaterialCard
               key={material.id}
               isBig={false}
@@ -86,7 +86,7 @@ const MaterialBox = () => {
           <HomeTagCardTitle title="결제 완료" isViewAll />
         </CardTitleWrapper>
         <CardsWrapper>
-          {materialsByState?.afterPay.map((material) => (
+          {materialsByState?.afterPay?.map((material) => (
             <HomeMaterialCard
               key={material.id}
               isBig={false}


### PR DESCRIPTION
# Description

- [x] 자료함이 비었을 때, 에러 페이지 대신 빈 페이지가 띄워지도록 수정.