### PR TITLE
fix: place backdrop in the right element

### DIFF
--- a/src/components/common/Modal/index.styles.tsx
+++ b/src/components/common/Modal/index.styles.tsx
@@ -21,6 +21,12 @@ export const StyledDialog = styled.dialog`
   box-sizing: border-box;
   padding: 0;
   border-radius: 16px;
+  appearance: none;
+
+  &&::backdrop {
+    appearance: none;
+    background-color: rgba(0, 0, 0, 0.5);
+  }
 `;
 
 export const StyledModalContainer = styled.div`
@@ -29,10 +35,6 @@ export const StyledModalContainer = styled.div`
   border-radius: 16px;
   padding: 28px 20px 20px 20px;
   box-sizing: border-box;
-
-  &::backdrop {
-    background-color: rgba(0, 0, 0, 0.5);
-  }
 `;
 
 export const StyledTitleRow = styled.div`


### PR DESCRIPTION
# Description

- [x] ::backdrop pseudo property는 dialog element에만 적용되어, div element에 적용된 style을 dialog에 올바르게 용