### PR TITLE
Feature/create bookmarked materials page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,11 @@ import GlobalStyle from './components/common/GlobalStyle';
 import useAutoSignin from './hooks/common/useAutoSignin';
 
 function App() {
-  useAutoSignin();
+  const { isSigninDone } = useAutoSignin();
+
+  if (!isSigninDone) {
+    return <span />;
+  }
 
   return (
     <>

--- a/src/apis/my.ts
+++ b/src/apis/my.ts
@@ -29,4 +29,46 @@ const getMyProfile = async (
   }
 };
 
+export const getMyBookmarks = async (
+  page: number,
+  pageSize: number,
+  accessToken: string,
+  refreshPayload: RetryPayload,
+) => {
+  const requestOptions = {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  };
+
+  const data = await fetchWithTokenRetry(
+    `${process.env.REACT_APP_API_URL}/my/bookmark?page=${page}&pageSize=${pageSize}`,
+    requestOptions,
+    refreshPayload,
+  );
+
+  return data;
+};
+
+export const getMyLikes = async (
+  page: number,
+  pageSize: number,
+  authStore: string,
+  refreshPayload: RetryPayload,
+) => {
+  const requestOptions = {
+    headers: {
+      Authorization: `Bearer ${authStore}`,
+    },
+  };
+
+  const data = await fetchWithTokenRetry(
+    `${process.env.REACT_APP_API_URL}/my/like?page=${page}&pageSize=${pageSize}`,
+    requestOptions,
+    refreshPayload,
+  );
+
+  return data;
+};
+
 export default getMyProfile;

--- a/src/components/common/TapMenu/index.tsx
+++ b/src/components/common/TapMenu/index.tsx
@@ -1,26 +1,30 @@
-import React, { useState } from 'react'
+import React, { useState } from 'react';
 
 import { Container, MenusWrapper } from './index.styles';
 import AllDividerThin from '../AllDividerThin';
 import TapMenuList from '../TapMenuList';
 
-function TapMenu() {
+interface TapMenuPropsType {
+  labels?: [string, string];
+}
+
+function TapMenu({ labels = ['구매', '판매'] }: TapMenuPropsType) {
   const [selectedItem, setSelectedItem] = useState(0);
 
   const handleItemClick = (index: number) => {
     setSelectedItem(index);
-  }
+  };
 
   const TapMenuArray = [
     {
       id: 1,
-      label: '구매',
+      label: labels[0],
     },
     {
       id: 2,
-      label: '판매',
-    }
-  ]
+      label: labels[1],
+    },
+  ];
 
   return (
     <Container>
@@ -33,10 +37,46 @@ function TapMenu() {
             isSelected={selectedItem === index}
           />
         ))}
-      </MenusWrapper>    
+      </MenusWrapper>
       <AllDividerThin />
     </Container>
-  )
+  );
 }
 
-export default TapMenu
+export function SelectableTapMenu({
+  labels = ['구매', '판매'],
+  selectedItem,
+  onItemClick,
+}: TapMenuPropsType & {
+  selectedItem: number;
+  onItemClick: (index: number) => void;
+}) {
+  const TapMenuArray = [
+    {
+      id: 1,
+      label: labels[0],
+    },
+    {
+      id: 2,
+      label: labels[1],
+    },
+  ];
+
+  return (
+    <Container>
+      <MenusWrapper>
+        {[...TapMenuArray].map((menuItem, index) => (
+          <TapMenuList
+            key={menuItem.id}
+            label={menuItem.label}
+            onClick={() => onItemClick(index)}
+            isSelected={selectedItem === index}
+          />
+        ))}
+      </MenusWrapper>
+      <AllDividerThin />
+    </Container>
+  );
+}
+
+export default TapMenu;

--- a/src/hooks/common/useAutoSignin/index.ts
+++ b/src/hooks/common/useAutoSignin/index.ts
@@ -1,12 +1,16 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import useAuthStore, { AuthLevel } from '../../../store/useAuthStore';
 
 // TODO check if access token
 // TODO if someone has access token, load it to global state and raise auth level to member
 
 export default function useAutoSignin() {
+  const [isSigninDone, setIsSigninDone] = useState(false);
   const restoreCredentials = useAuthStore((state) => state.restoreCredentials);
   useEffect(() => {
     restoreCredentials();
+    setIsSigninDone(true);
   }, [restoreCredentials]);
+
+  return { isSigninDone };
 }

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -2,11 +2,6 @@ import React, { useEffect, useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 import { ContentPageContainer, HomeContainer } from './index.styles';
-import {
-  MainLeftContainer,
-  MainRightContainer,
-  PageContainer,
-} from '../../components/common/GlobalStyle/index.styles';
 import AllDivider from '../../components/common/AllDivider';
 import HomeCategoryButtonSection from '../../components/home/HomeCategoryButtonSection';
 import HomeContentPageTitle from '../../components/home/HomeContentPageTitle';
@@ -116,184 +111,175 @@ const Home = () => {
   }, [currentCategory]);
 
   return (
-    <PageContainer>
-      <MainLeftContainer>
-        <MainLeftBoxTop />
-        <MainLeftBoxBottom />
-      </MainLeftContainer>
+    <>
+      <PrimaryTopbar
+        title={
+          <button
+            type="button"
+            onClick={() => {
+              navigate('/');
+            }}
+            aria-label="prev"
+          >
+            <AppLogoIcon />
+          </button>
+        }
+        icons={[
+          <button
+            type="button"
+            onClick={() =>
+              activateModal('TO_BE_UPDATED', {
+                primaryAction: () => {},
+              })
+            }
+            aria-label="cart"
+          >
+            <CartDefaultIcon />
+          </button>,
+          <button
+            type="button"
+            onClick={() =>
+              activateModal('TO_BE_UPDATED', {
+                primaryAction: () => {},
+              })
+            }
+            aria-label="alarm"
+          >
+            <NotificationDefaultIcon />
+          </button>,
+        ]}
+      />
+      <HomeContainer>
+        <BannerContainer>
+          <Banner />
+          <Banner />
+          <Banner />
+        </BannerContainer>
 
-      <MainRightContainer>
-        <PrimaryTopbar
-          title={
-            <button
-              type="button"
-              onClick={() => {
-                navigate('/');
-              }}
-              aria-label="prev"
-            >
-              <AppLogoIcon />
-            </button>
-          }
-          icons={[
-            <button
-              type="button"
-              onClick={() =>
-                activateModal('TO_BE_UPDATED', {
-                  primaryAction: () => {},
-                })
-              }
-              aria-label="cart"
-            >
-              <CartDefaultIcon />
-            </button>,
-            <button
-              type="button"
-              onClick={() =>
-                activateModal('TO_BE_UPDATED', {
-                  primaryAction: () => {},
-                })
-              }
-              aria-label="alarm"
-            >
-              <NotificationDefaultIcon />
-            </button>,
-          ]}
+        <HomeCategoryButtonSection
+          currentCategory={currentCategory}
+          updateCategory={updateCategory}
         />
-        <HomeContainer>
-          <BannerContainer>
-            <Banner />
-            <Banner />
-            <Banner />
-          </BannerContainer>
+        <AllDivider />
 
-          <HomeCategoryButtonSection
-            currentCategory={currentCategory}
-            updateCategory={updateCategory}
+        <ContentPageContainer>
+          <HomeContentPageTitle title={title} />
+
+          <HomeTagCardTitle
+            title="신규 등록 자료"
+            tag="new"
+            category={currentCategory}
           />
-          <AllDivider />
+          <HomeMaterialCardWrapper>
+            {homeMaterials?.newUpload ? (
+              homeMaterials.newUpload.map((material: Material) => {
+                return (
+                  <HomeMaterialCard
+                    key={material.id}
+                    isBig={false}
+                    id={material.id}
+                    memberId={material.memberId}
+                    imageUrl={material.imageUrl}
+                    nickname={material.nickname}
+                    className={material.className}
+                    univ={material.univ}
+                    major={material.major}
+                    semester={material.semester}
+                    professor={material.professor}
+                    like={material.like}
+                  />
+                );
+              })
+            ) : (
+              <>
+                <HomeMaterialCardSkeleton isBig={false} />
+                <HomeMaterialCardSkeleton isBig={false} />
+                <HomeMaterialCardSkeleton isBig={false} />
+                <HomeMaterialCardSkeleton isBig={false} />
+                <HomeMaterialCardSkeleton isBig={false} />
+              </>
+            )}
+          </HomeMaterialCardWrapper>
 
-          <ContentPageContainer>
-            <HomeContentPageTitle title={title} />
+          <HomeTagCardTitle
+            title="베스트 자료"
+            tag="hot"
+            category={currentCategory}
+          />
+          <HomeMaterialCardWrapper>
+            {homeMaterials?.best ? (
+              homeMaterials.best.map((material: Material) => {
+                return (
+                  <HomeMaterialCard
+                    key={material.id}
+                    isBig={false}
+                    id={material.id}
+                    memberId={material.memberId}
+                    imageUrl={material.imageUrl}
+                    nickname={material.nickname}
+                    className={material.className}
+                    univ={material.univ}
+                    major={material.major}
+                    semester={material.semester}
+                    professor={material.professor}
+                    like={material.like}
+                  />
+                );
+              })
+            ) : (
+              <>
+                <HomeMaterialCardSkeleton isBig={false} />
+                <HomeMaterialCardSkeleton isBig={false} />
+                <HomeMaterialCardSkeleton isBig={false} />
+                <HomeMaterialCardSkeleton isBig={false} />
+                <HomeMaterialCardSkeleton isBig={false} />
+              </>
+            )}
+          </HomeMaterialCardWrapper>
 
-            <HomeTagCardTitle
-              title="신규 등록 자료"
-              tag="new"
-              category={currentCategory}
-            />
-            <HomeMaterialCardWrapper>
-              {homeMaterials?.newUpload ? (
-                homeMaterials.newUpload.map((material: Material) => {
-                  return (
-                    <HomeMaterialCard
-                      key={material.id}
-                      isBig={false}
-                      id={material.id}
-                      memberId={material.memberId}
-                      imageUrl={material.imageUrl}
-                      nickname={material.nickname}
-                      className={material.className}
-                      univ={material.univ}
-                      major={material.major}
-                      semester={material.semester}
-                      professor={material.professor}
-                      like={material.like}
-                    />
-                  );
-                })
-              ) : (
-                <>
-                  <HomeMaterialCardSkeleton isBig={false} />
-                  <HomeMaterialCardSkeleton isBig={false} />
-                  <HomeMaterialCardSkeleton isBig={false} />
-                  <HomeMaterialCardSkeleton isBig={false} />
-                  <HomeMaterialCardSkeleton isBig={false} />
-                </>
-              )}
-            </HomeMaterialCardWrapper>
+          <HomeTagCardTitle title="최근에 본 자료" category={currentCategory} />
+          <HomeMaterialCardWrapper>
+            {recentMaterials ? (
+              recentMaterials.map((material: Material) => {
+                return (
+                  <HomeMaterialCard
+                    key={material.id}
+                    isBig={false}
+                    id={material.id}
+                    memberId={material.memberId}
+                    imageUrl={material.imageUrl}
+                    nickname={material.nickname}
+                    className={material.className}
+                    univ={material.univ}
+                    major={material.major}
+                    semester={material.semester}
+                    professor={material.professor}
+                    like={material.like}
+                  />
+                );
+              })
+            ) : (
+              <>
+                <HomeMaterialCardSkeleton isBig={false} />
+                <HomeMaterialCardSkeleton isBig={false} />
+                <HomeMaterialCardSkeleton isBig={false} />
+                <HomeMaterialCardSkeleton isBig={false} />
+                <HomeMaterialCardSkeleton isBig={false} />
+              </>
+            )}
+          </HomeMaterialCardWrapper>
+        </ContentPageContainer>
+      </HomeContainer>
 
-            <HomeTagCardTitle
-              title="베스트 자료"
-              tag="hot"
-              category={currentCategory}
-            />
-            <HomeMaterialCardWrapper>
-              {homeMaterials?.best ? (
-                homeMaterials.best.map((material: Material) => {
-                  return (
-                    <HomeMaterialCard
-                      key={material.id}
-                      isBig={false}
-                      id={material.id}
-                      memberId={material.memberId}
-                      imageUrl={material.imageUrl}
-                      nickname={material.nickname}
-                      className={material.className}
-                      univ={material.univ}
-                      major={material.major}
-                      semester={material.semester}
-                      professor={material.professor}
-                      like={material.like}
-                    />
-                  );
-                })
-              ) : (
-                <>
-                  <HomeMaterialCardSkeleton isBig={false} />
-                  <HomeMaterialCardSkeleton isBig={false} />
-                  <HomeMaterialCardSkeleton isBig={false} />
-                  <HomeMaterialCardSkeleton isBig={false} />
-                  <HomeMaterialCardSkeleton isBig={false} />
-                </>
-              )}
-            </HomeMaterialCardWrapper>
+      <BottomBar />
 
-            <HomeTagCardTitle
-              title="최근에 본 자료"
-              category={currentCategory}
-            />
-            <HomeMaterialCardWrapper>
-              {recentMaterials ? (
-                recentMaterials.map((material: Material) => {
-                  return (
-                    <HomeMaterialCard
-                      key={material.id}
-                      isBig={false}
-                      id={material.id}
-                      memberId={material.memberId}
-                      imageUrl={material.imageUrl}
-                      nickname={material.nickname}
-                      className={material.className}
-                      univ={material.univ}
-                      major={material.major}
-                      semester={material.semester}
-                      professor={material.professor}
-                      like={material.like}
-                    />
-                  );
-                })
-              ) : (
-                <>
-                  <HomeMaterialCardSkeleton isBig={false} />
-                  <HomeMaterialCardSkeleton isBig={false} />
-                  <HomeMaterialCardSkeleton isBig={false} />
-                  <HomeMaterialCardSkeleton isBig={false} />
-                  <HomeMaterialCardSkeleton isBig={false} />
-                </>
-              )}
-            </HomeMaterialCardWrapper>
-          </ContentPageContainer>
-        </HomeContainer>
-
-        <BottomBar />
-      </MainRightContainer>
       <Modal
         modalRef={modalRef}
         category={modalCategory}
         onPrimaryAction={closePrimarily}
         onSecondaryAction={closeSecondarily}
       />
-    </PageContainer>
+    </>
   );
 };
 

--- a/src/pages/HomeMaterialDetail/index.tsx
+++ b/src/pages/HomeMaterialDetail/index.tsx
@@ -9,7 +9,6 @@ import {
   StatisticsNumberWrapper,
   StickyBottom,
 } from './index.styles';
-import { MainLeftContainer, MainRightContainer, PageContainer } from '../../components/common/GlobalStyle/index.styles';
 import MaterialDetailPreview from '../../components/home/MaterialDetailPreview';
 import MaterialSellerProfile from '../../components/home/MaterialSellerProfile';
 import MaterialDetailPost from '../../components/home/MaterialDetailPost';
@@ -63,162 +62,146 @@ const HomeMaterialDetail = () => {
   };
 
   return materialDetail ? (
-    <PageContainer>
-      <MainLeftContainer>
-        <MainLeftBoxTop />
-        <MainLeftBoxBottom />
-      </MainLeftContainer>
+    <>
+      <SecondaryTopbar
+        transition={
+          <button type="button" onClick={() => navigate(-1)} aria-label="prev">
+            <ArrowBackDefaultIcon />
+          </button>
+        }
+        title={
+          <Text size={18} weight="bold" lineHeight="sm" color="gray/gray900">
+            자세히보기
+          </Text>
+        }
+        icons={[
+          <button
+            type="button"
+            onClick={() =>
+              activateModal('TO_BE_UPDATED', {
+                primaryAction: () => {},
+              })
+            }
+            aria-label="cart"
+          >
+            <CartDefaultIcon />
+          </button>,
+          <button
+            type="button"
+            onClick={() =>
+              activateModal('TO_BE_UPDATED', {
+                primaryAction: () => {},
+              })
+            }
+            aria-label="alarm"
+          >
+            <NotificationDefaultIcon />
+          </button>,
+        ]}
+      />
+      <Modal
+        modalRef={modalRef}
+        category={modalCategory}
+        onPrimaryAction={closePrimarily}
+        onSecondaryAction={closeSecondarily}
+      />
 
-      <MainRightContainer>
-        <SecondaryTopbar
-          transition={
-            <button type="button" onClick={() => navigate(-1)} aria-label='prev'>
-              <ArrowBackDefaultIcon />
-            </button>
-          }
-          title={
-            <Text size={18} weight="bold" lineHeight="sm" color="gray/gray900">
-              자세히보기
-            </Text>
-          }
-          icons={[
-            <button
-              type="button"
-              onClick={() =>
-                activateModal('TO_BE_UPDATED', {
-                  primaryAction: () => {},
-                })
-              }
-              aria-label='cart'
-            >
-              <CartDefaultIcon />
-            </button>,
-            <button
-              type="button"
-              onClick={() =>
-                activateModal('TO_BE_UPDATED', {
-                  primaryAction: () => {},
-                })
-              }
-              aria-label='alarm'
-            >
-              <NotificationDefaultIcon />
-            </button>,
-          ]}
-        />
-        <Modal
-          modalRef={modalRef}
-          category={modalCategory}
-          onPrimaryAction={closePrimarily}
-          onSecondaryAction={closeSecondarily}
-        />
-        
-        <DetailContainer>
-          <HomeMaterialDetailContainer>
-            <MaterialDetailPreview image={materialDetail.imageUrl} />
-
-            <ProfileWrapper>
-              <MaterialSellerProfile
-                id={materialDetail.id}
-                nickname={materialDetail.nickName}
-                hasReaction
-                like={materialDetail.like}
-                bookmark={materialDetail.bookmark}
-              />
-            </ProfileWrapper>
-            <AllDividerThin />
-
-            <MaterialDetailPost
-              title={materialDetail.title}
-              content={materialDetail.description}
-              updateTime={materialDetail.updateTime}
-            />
-
-            <AllDivider />
-
-            <StatisticsNumberWrapper>
-              <MaterialPostStatisticsNumber
-                sell={materialDetail.sell}
-                follower={materialDetail.follower}
-                reaction={materialDetail.bookmark + materialDetail.like}
-              />
-            </StatisticsNumberWrapper>
-
-            <AllDivider />
-
-            <MaterialDetailInfo
-              title={materialDetail.title}
-              university={materialDetail.university}
-              major={materialDetail.major}
-              semester={materialDetail.semester}
-              subjectTitle={materialDetail.subjectTitle}
-              professor={materialDetail.professor}
-              grade={materialDetail.grade}
-              score={materialDetail.score}
-              pages={materialDetail.pages}
-            />
-          </HomeMaterialDetailContainer>
-        </DetailContainer>
-
-        <StickyBottom>
-          <BottomPaymentAmount />
-          <ButtonWrapper>
-            <Button
-              type="button"
-              category="primary"
-              onClick={() => {
-                handleBuyNowClick();
-              }}
-            >
-              <Text color="gray/grayBG" size={16} weight="bold" lineHeight="sm">
-                바로구매
-              </Text>
-            </Button>
-          </ButtonWrapper>
-        </StickyBottom>
-      </MainRightContainer>
-    </PageContainer>
-  ) : (
-    // skeleton
-    <PageContainer>
-      <MainLeftContainer>
-        <MainLeftBoxTop />
-        <MainLeftBoxBottom />
-      </MainLeftContainer>
-
-      <MainRightContainer>
+      <DetailContainer>
         <HomeMaterialDetailContainer>
-          <MaterialDetailPreview image="" />
+          <MaterialDetailPreview image={materialDetail.imageUrl} />
 
           <ProfileWrapper>
-            <MaterialSellerProfile nickname="-" hasReaction={false} />
+            <MaterialSellerProfile
+              id={materialDetail.id}
+              nickname={materialDetail.nickName}
+              hasReaction
+              like={materialDetail.like}
+              bookmark={materialDetail.bookmark}
+            />
           </ProfileWrapper>
           <AllDividerThin />
 
-          <MaterialDetailPost title="-" content="-" updateTime="-" />
+          <MaterialDetailPost
+            title={materialDetail.title}
+            content={materialDetail.description}
+            updateTime={materialDetail.updateTime}
+          />
 
           <AllDivider />
 
           <StatisticsNumberWrapper>
-            <MaterialPostStatisticsNumber sell={0} follower={0} reaction={0} />
+            <MaterialPostStatisticsNumber
+              sell={materialDetail.sell}
+              follower={materialDetail.follower}
+              reaction={materialDetail.bookmark + materialDetail.like}
+            />
           </StatisticsNumberWrapper>
 
           <AllDivider />
 
           <MaterialDetailInfo
-            title=""
-            university=""
-            major=""
-            semester=""
-            subjectTitle=""
-            professor=""
-            grade=""
-            score={0}
-            pages={0}
+            title={materialDetail.title}
+            university={materialDetail.university}
+            major={materialDetail.major}
+            semester={materialDetail.semester}
+            subjectTitle={materialDetail.subjectTitle}
+            professor={materialDetail.professor}
+            grade={materialDetail.grade}
+            score={materialDetail.score}
+            pages={materialDetail.pages}
           />
         </HomeMaterialDetailContainer>
-      </MainRightContainer>
-    </PageContainer>
+      </DetailContainer>
+
+      <StickyBottom>
+        <BottomPaymentAmount />
+        <ButtonWrapper>
+          <Button
+            type="button"
+            category="primary"
+            onClick={() => {
+              handleBuyNowClick();
+            }}
+          >
+            <Text color="gray/grayBG" size={16} weight="bold" lineHeight="sm">
+              바로구매
+            </Text>
+          </Button>
+        </ButtonWrapper>
+      </StickyBottom>
+    </>
+  ) : (
+    // skeleton
+    <HomeMaterialDetailContainer>
+      <MaterialDetailPreview image="" />
+
+      <ProfileWrapper>
+        <MaterialSellerProfile nickname="-" hasReaction={false} />
+      </ProfileWrapper>
+      <AllDividerThin />
+
+      <MaterialDetailPost title="-" content="-" updateTime="-" />
+
+      <AllDivider />
+
+      <StatisticsNumberWrapper>
+        <MaterialPostStatisticsNumber sell={0} follower={0} reaction={0} />
+      </StatisticsNumberWrapper>
+
+      <AllDivider />
+
+      <MaterialDetailInfo
+        title=""
+        university=""
+        major=""
+        semester=""
+        subjectTitle=""
+        professor=""
+        grade=""
+        score={0}
+        pages={0}
+      />
+    </HomeMaterialDetailContainer>
   );
 };
 

--- a/src/pages/HomeViewAll/index.styles.tsx
+++ b/src/pages/HomeViewAll/index.styles.tsx
@@ -1,5 +1,5 @@
-import styled from "styled-components";
-import theme from "../../components/common/theme";
+import styled from 'styled-components';
+import theme from '../../components/common/theme';
 
 export const ViewAllContainer = styled.div`
   flex: 1; /* 상단바, 하단바 제외 나머지 영역 차지 */

--- a/src/pages/HomeViewAll/index.tsx
+++ b/src/pages/HomeViewAll/index.tsx
@@ -45,9 +45,9 @@ const HomeViewAll = () => {
   let tagCardTitle: string;
   const authStore = useAuthStore((state) => state.accessToken);
   const [page, setPage] = useState(0);
-  const [loading, setLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const bottomRef = useRef(null);
-  const [isLastPage, setIsLastPage] = useState(false);
+  const [hasLastPageReached, setHasLastPageReached] = useState(false);
   const recentMaterials = getArrayFromLocalStorage('recent-materials');
   const recentMaterialViewAll: MaterialViewAll = {
     page: 1,
@@ -96,7 +96,7 @@ const HomeViewAll = () => {
             newMaterials = await getAllUnivBestViewAll(nextPage, 10);
           } else if (tag === 'undefined') {
             setAllMaterials(recentMaterialViewAll);
-            setIsLastPage(true);
+            setHasLastPageReached(true);
           }
           break;
         case HOME_CATEGORY.MY_UNIV.toString():
@@ -127,7 +127,7 @@ const HomeViewAll = () => {
                 setAllMaterials(recentMyUnivViewAll);
               });
             }
-            setIsLastPage(true);
+            setHasLastPageReached(true);
           }
           break;
         case HOME_CATEGORY.MY_MAJOR.toString():
@@ -158,14 +158,14 @@ const HomeViewAll = () => {
                 setAllMaterials(recentMyMajorViewAll);
               });
             }
-            setIsLastPage(true);
+            setHasLastPageReached(true);
           }
           break;
         default:
           break;
       }
 
-      if (newMaterials?.end) setIsLastPage(true);
+      if (newMaterials?.end) setHasLastPageReached(true);
 
       if (newMaterials != null) {
         setAllMaterials((prevMaterials: MaterialViewAll | null) => ({
@@ -178,17 +178,17 @@ const HomeViewAll = () => {
       }
 
       setPage(nextPage);
-      setLoading(false);
+      setIsLoading(false);
     } catch (error) {
       // console.error('Error loading more materials:', error);
-      setLoading(false);
+      setIsLoading(false);
     }
   };
 
   const handleIntersection = (entries: IntersectionObserverEntry[]) => {
     const target = entries[0];
-    if (target.isIntersecting && !loading && !isLastPage) {
-      setLoading(true);
+    if (target.isIntersecting && !isLoading && !hasLastPageReached) {
+      setIsLoading(true);
       // 다음 페이지의 자료 불러오기
       loadMoreMaterials();
     }
@@ -198,7 +198,7 @@ const HomeViewAll = () => {
     const observer = new IntersectionObserver(handleIntersection, {
       root: null,
       rootMargin: '0px',
-      threshold: 0.1,
+      threshold: 1.0,
     });
 
     if (bottomRef.current) {
@@ -208,7 +208,7 @@ const HomeViewAll = () => {
     return () => {
       observer.disconnect();
     };
-  }, [loading, allMaterials]);
+  }, [isLoading, allMaterials]);
 
   return (
     <>
@@ -258,7 +258,7 @@ const HomeViewAll = () => {
           />
         </CardTitleWrapper>
         <CardsWrapper>
-          {allMaterials?.materialResponseList ? (
+          {allMaterials?.materialResponseList &&
             allMaterials.materialResponseList.map((material: Material) => {
               return (
                 <HomeMaterialCard
@@ -276,8 +276,8 @@ const HomeViewAll = () => {
                   like={material.like}
                 />
               );
-            })
-          ) : (
+            })}
+          {isLoading && (
             <>
               <HomeMaterialCardSkeleton isBig />
               <HomeMaterialCardSkeleton isBig />

--- a/src/pages/HomeViewAll/index.tsx
+++ b/src/pages/HomeViewAll/index.tsx
@@ -6,7 +6,6 @@ import {
   CardsWrapper,
   ViewAllContainer,
 } from './index.styles';
-import { MainLeftContainer, MainRightContainer, PageContainer } from '../../components/common/GlobalStyle/index.styles';
 import HomeTagCardTitle from '../../components/home/HomeTagCardTitle';
 import HomeMaterialCard from '../../components/home/HomeMaterialCard';
 import BottomBar from '../../components/common/BottomBar';
@@ -32,8 +31,7 @@ import {
 } from '../../assets/icons';
 import Text from '../../components/common/Text';
 import Modal from '../../components/common/Modal';
-import MainLeftBoxTop from '../../components/common/MainLeftBoxTop';
-import MainLeftBoxBottom from '../../components/common/MainLeftBoxBottom';
+
 import { getArrayFromLocalStorage } from '../../components/home/LocalStorageUtils';
 import { getMy } from '../../apis/member';
 import HomeMaterialCardSkeleton from '../../components/home/HomeMaterialCardSkeleton';
@@ -213,100 +211,93 @@ const HomeViewAll = () => {
   }, [loading, allMaterials]);
 
   return (
-    <PageContainer>
-      <MainLeftContainer>
-        <MainLeftBoxTop />
-        <MainLeftBoxBottom />
-      </MainLeftContainer>
-
-      <MainRightContainer>
-        <SecondaryTopbar
-          transition={
-            <button type="button" onClick={() => navigate(-1)} aria-label='prev'>
-              <ArrowBackDefaultIcon />
-            </button>
-          }
-          title={
-            <Text size={18} weight="bold" lineHeight="sm" color="gray/gray900">
-              모두보기
-            </Text>
-          }
-          icons={[
-            <button
-              type="button"
-              onClick={() =>
-                activateModal('TO_BE_UPDATED', {
-                  primaryAction: () => {},
-                })
-              }
-              aria-label='cart'
-            >
-              <CartDefaultIcon />
-            </button>,
-            <button
-              type="button"
-              onClick={() =>
-                activateModal('TO_BE_UPDATED', {
-                  primaryAction: () => {},
-                })
-              }
-              aria-label='alarm'
-            >
-              <NotificationDefaultIcon />
-            </button>,
-          ]}
-        />
-        <ViewAllContainer>
-          <CardTitleWrapper>
-            <HomeTagCardTitle
-              title={tagCardTitle}
-              tag={tag}
-              category={0}
-              isViewAll
-            />
-          </CardTitleWrapper>
-          <CardsWrapper>
-            {allMaterials?.materialResponseList ? (
-              allMaterials.materialResponseList.map((material: Material) => {
-                return (
-                  <HomeMaterialCard
-                    key={material.id}
-                    isBig
-                    id={material.id}
-                    memberId={material.memberId}
-                    imageUrl={material.imageUrl}
-                    nickname={material.nickname}
-                    className={material.className}
-                    univ={material.univ}
-                    major={material.major}
-                    semester={material.semester}
-                    professor={material.professor}
-                    like={material.like}
-                  />
-                );
+    <>
+      <SecondaryTopbar
+        transition={
+          <button type="button" onClick={() => navigate(-1)} aria-label="prev">
+            <ArrowBackDefaultIcon />
+          </button>
+        }
+        title={
+          <Text size={18} weight="bold" lineHeight="sm" color="gray/gray900">
+            모두보기
+          </Text>
+        }
+        icons={[
+          <button
+            type="button"
+            onClick={() =>
+              activateModal('TO_BE_UPDATED', {
+                primaryAction: () => {},
               })
-            ) : (
-              <>
-                <HomeMaterialCardSkeleton isBig />
-                <HomeMaterialCardSkeleton isBig />
-                <HomeMaterialCardSkeleton isBig />
-                <HomeMaterialCardSkeleton isBig />
-                <HomeMaterialCardSkeleton isBig />
-              </>
-            )}
-          </CardsWrapper>
-          
-          <div ref={bottomRef} style={{ height: '10px' }} />
-        </ViewAllContainer>
-        <BottomBar />
-        <Modal
-          modalRef={modalRef}
-          category={modalCategory}
-          onPrimaryAction={closePrimarily}
-          onSecondaryAction={closeSecondarily}
-        />
-      </MainRightContainer>
-    </PageContainer>
+            }
+            aria-label="cart"
+          >
+            <CartDefaultIcon />
+          </button>,
+          <button
+            type="button"
+            onClick={() =>
+              activateModal('TO_BE_UPDATED', {
+                primaryAction: () => {},
+              })
+            }
+            aria-label="alarm"
+          >
+            <NotificationDefaultIcon />
+          </button>,
+        ]}
+      />
+      <ViewAllContainer>
+        <CardTitleWrapper>
+          <HomeTagCardTitle
+            title={tagCardTitle}
+            tag={tag}
+            category={0}
+            isViewAll
+          />
+        </CardTitleWrapper>
+        <CardsWrapper>
+          {allMaterials?.materialResponseList ? (
+            allMaterials.materialResponseList.map((material: Material) => {
+              return (
+                <HomeMaterialCard
+                  key={material.id}
+                  isBig
+                  id={material.id}
+                  memberId={material.memberId}
+                  imageUrl={material.imageUrl}
+                  nickname={material.nickname}
+                  className={material.className}
+                  univ={material.univ}
+                  major={material.major}
+                  semester={material.semester}
+                  professor={material.professor}
+                  like={material.like}
+                />
+              );
+            })
+          ) : (
+            <>
+              <HomeMaterialCardSkeleton isBig />
+              <HomeMaterialCardSkeleton isBig />
+              <HomeMaterialCardSkeleton isBig />
+              <HomeMaterialCardSkeleton isBig />
+              <HomeMaterialCardSkeleton isBig />
+            </>
+          )}
+        </CardsWrapper>
+
+        <div ref={bottomRef} style={{ height: '10px' }} />
+      </ViewAllContainer>
+      <BottomBar />
+      <Modal
+        modalRef={modalRef}
+        category={modalCategory}
+        onPrimaryAction={closePrimarily}
+        onSecondaryAction={closeSecondarily}
+      />
+    </>
   );
 };
 

--- a/src/pages/MaterialBox/index.tsx
+++ b/src/pages/MaterialBox/index.tsx
@@ -4,11 +4,6 @@ import {
   CardsWrapper,
   MaterialBoxContainer,
 } from './index.styles';
-import {
-  MainLeftContainer,
-  MainRightContainer,
-  PageContainer,
-} from '../../components/common/GlobalStyle/index.styles';
 import HomeTagCardTitle from '../../components/home/HomeTagCardTitle';
 import HomeMaterialCard from '../../components/home/HomeMaterialCard';
 import TapMenu from '../../components/common/TapMenu';
@@ -16,8 +11,6 @@ import BottomBar from '../../components/common/BottomBar';
 import useAuthStore from '../../store/useAuthStore';
 import getPurchaseInfo from '../../apis/library';
 import useRefreshPayload from '../../hooks/common/useRefreshPayload';
-import MainLeftBoxTop from '../../components/common/MainLeftBoxTop';
-import MainLeftBoxBottom from '../../components/common/MainLeftBoxBottom';
 
 interface PurchasedItemType {
   id: number;
@@ -63,69 +56,63 @@ const MaterialBox = () => {
   }, []);
 
   return (
-    <PageContainer>
-      <MainLeftContainer>
-        <MainLeftBoxTop />
-        <MainLeftBoxBottom />
-      </MainLeftContainer>
-      <MainRightContainer>
-        <MaterialBoxContainer>
-          <TapMenu />
-          <CardTitleWrapper>
-            <HomeTagCardTitle title="결제 대기" isViewAll />
-            {}
-          </CardTitleWrapper>
-          <CardsWrapper>
-            {materialsByState?.beforePay.map((material) => (
-              <HomeMaterialCard
-                key={material.id}
-                isBig={false}
-                id={material.id}
-                memberId={material.member_id}
-                imageUrl={material.member_profile_image}
-                nickname={material.nickname}
-                className={material.className}
-                univ={material.univ}
-                major={material.major}
-                semester={material.semester}
-                professor={material.professor}
-                like={material.like}
-              />
-            ))}
-            {/* <HomeMaterialCard />
+    <>
+      <MaterialBoxContainer>
+        <TapMenu />
+        <CardTitleWrapper>
+          <HomeTagCardTitle title="결제 대기" isViewAll />
+          {}
+        </CardTitleWrapper>
+        <CardsWrapper>
+          {materialsByState?.beforePay.map((material) => (
+            <HomeMaterialCard
+              key={material.id}
+              isBig={false}
+              id={material.id}
+              memberId={material.member_id}
+              imageUrl={material.member_profile_image}
+              nickname={material.nickname}
+              className={material.className}
+              univ={material.univ}
+              major={material.major}
+              semester={material.semester}
+              professor={material.professor}
+              like={material.like}
+            />
+          ))}
+          {/* <HomeMaterialCard />
             <HomeMaterialCard />
             <HomeMaterialCard /> */}
-          </CardsWrapper>
+        </CardsWrapper>
 
-          <CardTitleWrapper>
-            <HomeTagCardTitle title="결제 완료" isViewAll />
-          </CardTitleWrapper>
-          <CardsWrapper>
-            {materialsByState?.afterPay.map((material) => (
-              <HomeMaterialCard
-                key={material.id}
-                isBig={false}
-                id={material.id}
-                memberId={material.member_id}
-                imageUrl={material.member_profile_image}
-                nickname={material.nickname}
-                className={material.className}
-                univ={material.univ}
-                major={material.major}
-                semester={material.semester}
-                professor={material.professor}
-                like={material.like}
-              />
-            ))}
-            {/* <HomeMaterialCard />
+        <CardTitleWrapper>
+          <HomeTagCardTitle title="결제 완료" isViewAll />
+        </CardTitleWrapper>
+        <CardsWrapper>
+          {materialsByState?.afterPay.map((material) => (
+            <HomeMaterialCard
+              key={material.id}
+              isBig={false}
+              id={material.id}
+              memberId={material.member_id}
+              imageUrl={material.member_profile_image}
+              nickname={material.nickname}
+              className={material.className}
+              univ={material.univ}
+              major={material.major}
+              semester={material.semester}
+              professor={material.professor}
+              like={material.like}
+            />
+          ))}
+          {/* <HomeMaterialCard />
             <HomeMaterialCard />
             <HomeMaterialCard /> */}
-          </CardsWrapper>
-        </MaterialBoxContainer>
+        </CardsWrapper>
+      </MaterialBoxContainer>
 
-        <BottomBar />
-      </MainRightContainer>
-    </PageContainer>
+      <BottomBar />
+    </>
   );
 };
 

--- a/src/pages/My/Bookmarks/index.tsx
+++ b/src/pages/My/Bookmarks/index.tsx
@@ -1,5 +1,175 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import HOME_CATEGORY from '../../../components/home/HomeCategory/index.types';
+import { getMyBookmarks } from '../../../apis/my';
+import Material, {
+  MaterialViewAll,
+} from '../../../components/home/Material/index.types';
+import useAuthStore from '../../../store/useAuthStore';
+import useModal from '../../../hooks/common/useModal';
+import useRefreshPayload from '../../../hooks/common/useRefreshPayload';
+import { SecondaryTopbar } from '../../../components/common/TopBar';
+import { ArrowBackDefaultIcon } from '../../../assets/icons';
+import {
+  CardTitleWrapper,
+  CardsWrapper,
+  ViewAllContainer,
+} from '../../HomeViewAll/index.styles';
+import HomeTagCardTitle from '../../../components/home/HomeTagCardTitle';
+import HomeMaterialCard from '../../../components/home/HomeMaterialCard';
+import HomeMaterialCardSkeleton from '../../../components/home/HomeMaterialCardSkeleton';
+import Text from '../../../components/common/Text';
+
+interface MyBookmarkType {
+  nickName: string;
+  profileUrl: string;
+  className: string;
+  university: string;
+  major: string;
+  type: 'pdf';
+  totalRecommend: number;
+}
+
+interface MyMaterialListType {
+  page: number;
+  myMaterialList: MyBookmarkType[];
+}
 
 export default function Bookmarks() {
-  return <div>Bookmarks</div>;
+  const [allMaterials, setAllMaterials] = useState<null | MyMaterialListType>(
+    null,
+  );
+  const tagCardTitle = '최근 북마크순';
+
+  const accessToken = useAuthStore((state) => state.accessToken)!;
+  const [page, setPage] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const bottomRef = useRef(null);
+  const [hasLastPageReached, setHasLastPageReached] = useState(false);
+
+  const navigate = useNavigate();
+  const {
+    modalRef,
+    category: modalCategory,
+    activateModal,
+    closePrimarily,
+    closeSecondarily,
+  } = useModal();
+
+  const refreshPayload = useRefreshPayload();
+
+  const loadMoreMaterials = async () => {
+    const nextPage = page + 1;
+    let newMaterials: MyMaterialListType | null = null;
+    const data = await getMyBookmarks(
+      nextPage,
+      10,
+      accessToken,
+      refreshPayload,
+    );
+    const { code, result, status } = data;
+    console.log(data);
+
+    newMaterials = result;
+
+    if (status === 404 || code === 8001) {
+      setHasLastPageReached(true);
+      setIsLoading(false);
+      return;
+    }
+    // if (newMaterials?.end) setHasLastPageReached(true);
+
+    if (newMaterials != null) {
+      setAllMaterials((prevMaterials: MyMaterialListType | null) => ({
+        ...prevMaterials!,
+        myMaterialList: [
+          ...(prevMaterials?.myMaterialList || []),
+          ...(newMaterials?.myMaterialList || []),
+        ],
+      }));
+    }
+
+    setPage(nextPage);
+    setIsLoading(false);
+  };
+
+  const handleIntersection = (entries: IntersectionObserverEntry[]) => {
+    const target = entries[0];
+    if (target.isIntersecting && !isLoading && !hasLastPageReached) {
+      setIsLoading(true);
+      // 다음 페이지의 자료 불러오기
+      loadMoreMaterials();
+    }
+  };
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleIntersection, {
+      root: null,
+      rootMargin: '0px',
+      threshold: 1.0,
+    });
+
+    if (bottomRef.current) {
+      observer.observe(bottomRef.current);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [isLoading, allMaterials]);
+
+  return (
+    <>
+      <SecondaryTopbar
+        transition={
+          <button type="button" onClick={() => navigate(-1)} aria-label="prev">
+            <ArrowBackDefaultIcon />
+          </button>
+        }
+        title={
+          <Text size={18} weight="bold" lineHeight="sm" color="gray/gray900">
+            북마크한 자료
+          </Text>
+        }
+      />
+      <ViewAllContainer>
+        <CardTitleWrapper>
+          <HomeTagCardTitle title={tagCardTitle} tag="new" isViewAll />
+        </CardTitleWrapper>
+        <CardsWrapper>
+          {allMaterials?.myMaterialList &&
+            allMaterials.myMaterialList.map(
+              (material: MyBookmarkType, index) => {
+                return (
+                  <HomeMaterialCard
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={index}
+                    isBig
+                    nickname={material.nickName}
+                    imageUrl={material.profileUrl}
+                    className={material.className}
+                    univ={material.university}
+                    major={material.major}
+                    like={material.totalRecommend}
+                    id={0}
+                    memberId={0}
+                    semester="23-1"
+                  />
+                );
+              },
+            )}
+          {isLoading && (
+            <>
+              <HomeMaterialCardSkeleton isBig />
+              <HomeMaterialCardSkeleton isBig />
+              <HomeMaterialCardSkeleton isBig />
+              <HomeMaterialCardSkeleton isBig />
+              <HomeMaterialCardSkeleton isBig />
+            </>
+          )}
+        </CardsWrapper>
+        <div ref={bottomRef} style={{ height: '10px' }} />
+      </ViewAllContainer>
+    </>
+  );
 }

--- a/src/pages/My/Bookmarks/index.tsx
+++ b/src/pages/My/Bookmarks/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Bookmarks() {
+  return <div>Bookmarks</div>;
+}

--- a/src/pages/My/Likes/index.tsx
+++ b/src/pages/My/Likes/index.tsx
@@ -1,5 +1,169 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import HOME_CATEGORY from '../../../components/home/HomeCategory/index.types';
+import { getMyBookmarks, getMyLikes } from '../../../apis/my';
+import Material, {
+  MaterialViewAll,
+} from '../../../components/home/Material/index.types';
+import useAuthStore from '../../../store/useAuthStore';
+import useModal from '../../../hooks/common/useModal';
+import useRefreshPayload from '../../../hooks/common/useRefreshPayload';
+import { SecondaryTopbar } from '../../../components/common/TopBar';
+import { ArrowBackDefaultIcon } from '../../../assets/icons';
+import {
+  CardTitleWrapper,
+  CardsWrapper,
+  ViewAllContainer,
+} from '../../HomeViewAll/index.styles';
+import HomeTagCardTitle from '../../../components/home/HomeTagCardTitle';
+import HomeMaterialCard from '../../../components/home/HomeMaterialCard';
+import HomeMaterialCardSkeleton from '../../../components/home/HomeMaterialCardSkeleton';
+import Text from '../../../components/common/Text';
 
-export default function Likes() {
-  return <div>Likes</div>;
+interface MyBookmarkType {
+  nickName: string;
+  profileUrl: string;
+  className: string;
+  university: string;
+  major: string;
+  type: 'pdf';
+  totalRecommend: number;
+}
+
+interface MyMaterialListType {
+  page: number;
+  myMaterialList: MyBookmarkType[];
+}
+
+export default function Bookmarks() {
+  const [allMaterials, setAllMaterials] = useState<null | MyMaterialListType>(
+    null,
+  );
+  const tagCardTitle = '최근 좋아요순';
+
+  const accessToken = useAuthStore((state) => state.accessToken)!;
+  const [page, setPage] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const bottomRef = useRef(null);
+  const [hasLastPageReached, setHasLastPageReached] = useState(false);
+
+  const navigate = useNavigate();
+  const {
+    modalRef,
+    category: modalCategory,
+    activateModal,
+    closePrimarily,
+    closeSecondarily,
+  } = useModal();
+
+  const refreshPayload = useRefreshPayload();
+
+  const loadMoreMaterials = async () => {
+    const nextPage = page + 1;
+    let newMaterials: MyMaterialListType | null = null;
+    const data = await getMyLikes(nextPage, 10, accessToken, refreshPayload);
+    const { code, result, status } = data;
+
+    newMaterials = result;
+
+    if (status === 404 || code === 8001) {
+      setHasLastPageReached(true);
+      setIsLoading(false);
+      return;
+    }
+    // if (newMaterials?.end) setHasLastPageReached(true);
+
+    if (newMaterials != null) {
+      setAllMaterials((prevMaterials: MyMaterialListType | null) => ({
+        ...prevMaterials!,
+        myMaterialList: [
+          ...(prevMaterials?.myMaterialList || []),
+          ...(newMaterials?.myMaterialList || []),
+        ],
+      }));
+    }
+
+    setPage(nextPage);
+    setIsLoading(false);
+  };
+
+  const handleIntersection = (entries: IntersectionObserverEntry[]) => {
+    const target = entries[0];
+    if (target.isIntersecting && !isLoading && !hasLastPageReached) {
+      setIsLoading(true);
+      // 다음 페이지의 자료 불러오기
+      loadMoreMaterials();
+    }
+  };
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleIntersection, {
+      root: null,
+      rootMargin: '0px',
+      threshold: 1.0,
+    });
+
+    if (bottomRef.current) {
+      observer.observe(bottomRef.current);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [isLoading, allMaterials]);
+
+  return (
+    <>
+      <SecondaryTopbar
+        transition={
+          <button type="button" onClick={() => navigate(-1)} aria-label="prev">
+            <ArrowBackDefaultIcon />
+          </button>
+        }
+        title={
+          <Text size={18} weight="bold" lineHeight="sm" color="gray/gray900">
+            좋아요한 자료
+          </Text>
+        }
+      />
+      <ViewAllContainer>
+        <CardTitleWrapper>
+          <HomeTagCardTitle title={tagCardTitle} tag="new" isViewAll />
+        </CardTitleWrapper>
+        <CardsWrapper>
+          {allMaterials?.myMaterialList &&
+            allMaterials.myMaterialList.map(
+              (material: MyBookmarkType, index) => {
+                return (
+                  <HomeMaterialCard
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={index}
+                    isBig
+                    nickname={material.nickName}
+                    imageUrl={material.profileUrl}
+                    className={material.className}
+                    univ={material.university}
+                    major={material.major}
+                    like={material.totalRecommend}
+                    id={0}
+                    memberId={0}
+                    semester="23-1"
+                  />
+                );
+              },
+            )}
+          {isLoading && (
+            <>
+              <HomeMaterialCardSkeleton isBig />
+              <HomeMaterialCardSkeleton isBig />
+              <HomeMaterialCardSkeleton isBig />
+              <HomeMaterialCardSkeleton isBig />
+              <HomeMaterialCardSkeleton isBig />
+            </>
+          )}
+        </CardsWrapper>
+        <div ref={bottomRef} style={{ height: '10px' }} />
+      </ViewAllContainer>
+    </>
+  );
 }

--- a/src/pages/My/Likes/index.tsx
+++ b/src/pages/My/Likes/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Likes() {
+  return <div>Likes</div>;
+}

--- a/src/pages/My/MyMain/index.tsx
+++ b/src/pages/My/MyMain/index.tsx
@@ -17,9 +17,7 @@ import useMyProfile from './useMyProfile';
 import { SecondaryTopbar } from '../../../components/common/TopBar';
 import { ArrowBackDefaultIcon, ViewMoreIcon } from '../../../assets/icons';
 import StyledPageContainer from '../../Upload/UploadDefaultStep/index.styles';
-import { MainLeftContainer, MainRightContainer, PageContainer } from '../../../components/common/GlobalStyle/index.styles';
-import MainLeftBoxTop from '../../../components/common/MainLeftBoxTop';
-import MainLeftBoxBottom from '../../../components/common/MainLeftBoxBottom';
+
 import BottomBar from '../../../components/common/BottomBar';
 
 export default function MyMain() {
@@ -55,45 +53,38 @@ export default function MyMain() {
   );
 
   return (
-    <PageContainer>
-      <MainLeftContainer>
-        <MainLeftBoxTop />
-        <MainLeftBoxBottom />
-      </MainLeftContainer>
+    <>
+      <SecondaryTopbar
+        transition={
+          <button type="button" onClick={() => navigate(-1)} aria-label="prev">
+            <ArrowBackDefaultIcon />
+          </button>
+        }
+        title={
+          <Text size={18} weight="bold" lineHeight="sm" color="gray/gray900">
+            MY
+          </Text>
+        }
+        icons={[
+          <button type="button" onClick={() => navigate('./view-more')}>
+            <ViewMoreIcon />
+          </button>,
+        ]}
+      />
+      <StyledPageContainer>
+        <StyledProfileSection>
+          <StyledProfileIntro>
+            <StyledWelcomeSection>
+              <div>{welcomeText}</div>
+              <StyledTagSection>{tags}</StyledTagSection>
+            </StyledWelcomeSection>
+            <StyledPortrait />
+          </StyledProfileIntro>
+          {countInfoRow}
+        </StyledProfileSection>
+      </StyledPageContainer>
 
-      <MainRightContainer>
-        <SecondaryTopbar
-          transition={
-            <button type="button" onClick={() => navigate(-1)} aria-label='prev'>
-              <ArrowBackDefaultIcon />
-            </button>
-          }
-          title={
-            <Text size={18} weight="bold" lineHeight="sm" color="gray/gray900">
-              MY
-            </Text>
-          }
-          icons={[
-            <button type="button" onClick={() => navigate('./view-more')}>
-              <ViewMoreIcon />
-            </button>,
-          ]}
-        />
-        <StyledPageContainer>
-          <StyledProfileSection>
-            <StyledProfileIntro>
-              <StyledWelcomeSection>
-                <div>{welcomeText}</div>
-                <StyledTagSection>{tags}</StyledTagSection>
-              </StyledWelcomeSection>
-              <StyledPortrait />
-            </StyledProfileIntro>
-            {countInfoRow}
-          </StyledProfileSection>
-        </StyledPageContainer>
-        
-        <BottomBar />
-      </MainRightContainer>
-    </PageContainer>
+      <BottomBar />
+    </>
   );
 }

--- a/src/pages/My/MyMain/index.tsx
+++ b/src/pages/My/MyMain/index.tsx
@@ -19,6 +19,8 @@ import { ArrowBackDefaultIcon, ViewMoreIcon } from '../../../assets/icons';
 import StyledPageContainer from '../../Upload/UploadDefaultStep/index.styles';
 
 import BottomBar from '../../../components/common/BottomBar';
+import Column from '../../../components/common/Column';
+import RowButton from '../../../components/common/RowButton';
 
 export default function MyMain() {
   const { nickName, univName, major, image_url, upload, sell, follower } =
@@ -82,6 +84,22 @@ export default function MyMain() {
           </StyledProfileIntro>
           {countInfoRow}
         </StyledProfileSection>
+        <Column>
+          <RowButton
+            text="북마크한 자료"
+            onClick={() => navigate('./bookmarks')}
+          />
+          <RowButton text="좋아요한 자료" onClick={() => navigate('./likes')} />
+          <RowButton
+            text="거래 내역"
+            onClick={() => navigate('../transactions')}
+          />
+          <RowButton
+            type="button"
+            text="쿠폰함"
+            onClick={() => navigate('/')}
+          />
+        </Column>
       </StyledPageContainer>
 
       <BottomBar />

--- a/src/pages/My/Transactions/index.tsx
+++ b/src/pages/My/Transactions/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Transactions() {
+  return <div>Transactions</div>;
+}

--- a/src/pages/My/Transactions/index.tsx
+++ b/src/pages/My/Transactions/index.tsx
@@ -1,5 +1,39 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { SecondaryTopbar } from '../../../components/common/TopBar';
+import { ArrowBackDefaultIcon } from '../../../assets/icons';
+import Text from '../../../components/common/Text';
+import TapMenu, { SelectableTapMenu } from '../../../components/common/TapMenu';
 
 export default function Transactions() {
-  return <div>Transactions</div>;
+  const [selectedTab, setSelectedTab] = useState<number>(0);
+
+  const topBar = (
+    <SecondaryTopbar
+      transition={
+        <button type="button" onClick={() => {}} aria-label="prev">
+          <ArrowBackDefaultIcon />
+        </button>
+      }
+      title={
+        <Text color="gray/gray900" size={18} weight="bold" lineHeight="sm">
+          거래 내역
+        </Text>
+      }
+    />
+  );
+
+  const tabBar = (
+    <SelectableTapMenu
+      labels={['구매 내역', '판매 내역']}
+      selectedItem={selectedTab}
+      onItemClick={(index) => setSelectedTab(index)}
+    />
+  );
+
+  return (
+    <>
+      {topBar}
+      {tabBar}
+    </>
+  );
 }

--- a/src/pages/RemittanceAdvice/index.tsx
+++ b/src/pages/RemittanceAdvice/index.tsx
@@ -13,7 +13,7 @@ import {
   ButtonWrapper,
   CopyButton,
 } from './index.styles';
-import { MainLeftContainer, MainRightContainer, PageContainer } from '../../components/common/GlobalStyle/index.styles';
+
 import AllDivider from '../../components/common/AllDivider';
 import Text from '../../components/common/Text';
 import BottomPaymentAmount from '../../components/home/BottomPaymentAmount';
@@ -21,8 +21,6 @@ import Button from '../../components/common/Button';
 import useAuthStore from '../../store/useAuthStore';
 import { cancelPayment, getBuyInfo } from '../../apis/payments';
 import { OrderInfo } from '../../components/home/Payment/index.types';
-import MainLeftBoxTop from '../../components/common/MainLeftBoxTop';
-import MainLeftBoxBottom from '../../components/common/MainLeftBoxBottom';
 import useModal from '../../hooks/common/useModal';
 import Modal from '../../components/common/Modal';
 import useRefreshPayload from '../../hooks/common/useRefreshPayload';
@@ -80,123 +78,116 @@ const RemittanceAdvice = () => {
   }, [buyInfoId, authStore, setBuyInfo]);
 
   return (
-    <PageContainer>
-      <MainLeftContainer>
-        <MainLeftBoxTop />
-        <MainLeftBoxBottom />
-      </MainLeftContainer>
+    <>
+      <AdviceContainer>
+        <RemittanceContainer>
+          <MarginBottom4>
+            <Text
+              size={20}
+              weight="bold"
+              lineHeight="sm"
+              color="main_color/blue_p"
+            >
+              4,700원
+            </Text>
+          </MarginBottom4>
+          <Text weight="bold" lineHeight="sm" color="gray/gray900">
+            {' '}
+            {materialInfo.title}{' '}
+          </Text>
+          <Text size={12} color="gray/gray500">
+            14일 이내로 송금해주세요 (요청일 : {buyInfo?.createDate})<br />
+            주문번호 : {buyInfoId}
+          </Text>
+        </RemittanceContainer>
 
-      <MainRightContainer>     
-        <AdviceContainer>
-          <RemittanceContainer>
-            <MarginBottom4>
-              <Text
-                size={20}
-                weight="bold"
-                lineHeight="sm"
-                color="main_color/blue_p"
-              >
-                4,700원
-              </Text>
-            </MarginBottom4>
-            <Text weight="bold" lineHeight="sm" color="gray/gray900">
+        <AllDivider />
+
+        <CodeAdviceContainer>
+          <MarginBottom16>
+            <Text size={22} lineHeight="lg" color="gray/gray900">
+              아래 식별코드를
+            </Text>
+            <Text size={22} weight="bold" lineHeight="lg" color="gray/gray900">
+              송금자명에 붙여넣어주세요
+            </Text>
+          </MarginBottom16>
+
+          <CodeContainer>
+            <Text size={16} lineHeight="lg" color="main_color/blue_p">
               {' '}
-              {materialInfo.title}{' '}
+              {buyInfo?.code}{' '}
             </Text>
-            <Text size={12} color="gray/gray500">
-              14일 이내로 송금해주세요 (요청일 : {buyInfo?.createDate})<br />
-              주문번호 : {buyInfoId}
+            <CopyButton
+              onClick={() => {
+                hanelCopyClick(buyInfo?.code);
+              }}
+            />
+          </CodeContainer>
+
+          <HelperTextWrapper>
+            <HelperInfoIcon />
+            <Text size={12} lineHeight="lg" color="gray/gray400">
+              송금이 확인되는 대로 자료를 사용할 수 있으며, <br />
+              최대 3 영업일이 소요될 수 있습니다.
             </Text>
-          </RemittanceContainer>
+          </HelperTextWrapper>
+          <HelperTextWrapper>
+            <HelperInfoIcon />
+            <Text size={12} lineHeight="lg" color="gray/gray400">
+              입금 전까지 ‘구매 내역’에서 구매를 취소할 수 있으며, <br />
+              입금 후 자료 열람 전까지 ‘자료함’에서 환불요청할 수 있습니다.
+            </Text>
+          </HelperTextWrapper>
+          <HelperTextWrapper>
+            <HelperInfoIcon />
+            <Text size={12} lineHeight="lg" color="gray/gray400">
+              하나의 주문으로 묶인 자료는 한 번에 결제가 필요합니다. <br />
+              개별 자료 구매를 원하시면 구매 취소 후 각각 주문해주세요.
+            </Text>
+          </HelperTextWrapper>
+        </CodeAdviceContainer>
+      </AdviceContainer>
 
-          <AllDivider />
-
-          <CodeAdviceContainer>
-            <MarginBottom16>
-              <Text size={22} lineHeight="lg" color="gray/gray900">
-                아래 식별코드를
-              </Text>
-              <Text size={22} weight="bold" lineHeight="lg" color="gray/gray900">
-                송금자명에 붙여넣어주세요
-              </Text>
-            </MarginBottom16>
-
-            <CodeContainer>
-              <Text size={16} lineHeight="lg" color="main_color/blue_p">
-                {' '}
-                {buyInfo?.code}{' '}
-              </Text>
-              <CopyButton
-                onClick={() => {
-                  hanelCopyClick(buyInfo?.code);
-                }}
-              />
-            </CodeContainer>
-
-            <HelperTextWrapper>
-              <HelperInfoIcon />
-              <Text size={12} lineHeight="lg" color="gray/gray400">
-                송금이 확인되는 대로 자료를 사용할 수 있으며, <br />
-                최대 3 영업일이 소요될 수 있습니다.
-              </Text>
-            </HelperTextWrapper>
-            <HelperTextWrapper>
-              <HelperInfoIcon />
-              <Text size={12} lineHeight="lg" color="gray/gray400">
-                입금 전까지 ‘구매 내역’에서 구매를 취소할 수 있으며, <br />
-                입금 후 자료 열람 전까지 ‘자료함’에서 환불요청할 수 있습니다.
-              </Text>
-            </HelperTextWrapper>
-            <HelperTextWrapper>
-              <HelperInfoIcon />
-              <Text size={12} lineHeight="lg" color="gray/gray400">
-                하나의 주문으로 묶인 자료는 한 번에 결제가 필요합니다. <br />
-                개별 자료 구매를 원하시면 구매 취소 후 각각 주문해주세요.
-              </Text>
-            </HelperTextWrapper>
-          </CodeAdviceContainer>
-        </AdviceContainer>
-
-        <StickyBottom>
-          <BottomPaymentAmount />
-          <ButtonWrapper>
-            <Button
-              type="button"
-              category="secondary"
-              onClick={() => {
-                handleCancelClick();
-              }}
+      <StickyBottom>
+        <BottomPaymentAmount />
+        <ButtonWrapper>
+          <Button
+            type="button"
+            category="secondary"
+            onClick={() => {
+              handleCancelClick();
+            }}
+          >
+            <Text
+              color="main_color/blue_p"
+              size={16}
+              weight="bold"
+              lineHeight="sm"
             >
-              <Text
-                color="main_color/blue_p"
-                size={16}
-                weight="bold"
-                lineHeight="sm"
-              >
-                구매취소
-              </Text>
-            </Button>
-            <Button
-              type="button"
-              category="primary"
-              onClick={() => {
-                handleRemittanceClick();
-              }}
-            >
-              <Text color="gray/grayBG" size={16} weight="bold" lineHeight="sm">
-                송금하기
-              </Text>
-            </Button>
-          </ButtonWrapper>
-        </StickyBottom>
-        
-        <Modal
-          {...modalProps}
-          onPrimaryAction={closePrimarily}
-          onSecondaryAction={closeSecondarily}
-        />
-      </MainRightContainer>
-    </PageContainer>
+              구매취소
+            </Text>
+          </Button>
+          <Button
+            type="button"
+            category="primary"
+            onClick={() => {
+              handleRemittanceClick();
+            }}
+          >
+            <Text color="gray/grayBG" size={16} weight="bold" lineHeight="sm">
+              송금하기
+            </Text>
+          </Button>
+        </ButtonWrapper>
+      </StickyBottom>
+
+      <Modal
+        {...modalProps}
+        onPrimaryAction={closePrimarily}
+        onSecondaryAction={closeSecondarily}
+      />
+    </>
   );
 };
 

--- a/src/pages/RootContainer/index.tsx
+++ b/src/pages/RootContainer/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import {
+  MainLeftContainer,
+  MainRightContainer,
+  PageContainer,
+} from '../../components/common/GlobalStyle/index.styles';
+import MainLeftBoxTop from '../../components/common/MainLeftBoxTop';
+import MainLeftBoxBottom from '../../components/common/MainLeftBoxBottom';
+
+export default function RootContainer() {
+  return (
+    <PageContainer>
+      <MainLeftContainer>
+        <MainLeftBoxTop />
+        <MainLeftBoxBottom />
+      </MainLeftContainer>
+      <MainRightContainer>
+        <Outlet />
+      </MainRightContainer>
+    </PageContainer>
+  );
+}

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -13,11 +13,6 @@ import { KakaoIcon } from '../../assets/icons';
 import Button from '../../components/common/Button';
 import useSignin from './useSignin';
 import useAuthStore, { AuthLevel } from '../../store/useAuthStore';
-import {
-  MainLeftContainer,
-  MainRightContainer,
-  PageContainer,
-} from '../../components/common/GlobalStyle/index.styles';
 import MainLeftBoxTop from '../../components/common/MainLeftBoxTop';
 import MainLeftBoxBottom from '../../components/common/MainLeftBoxBottom';
 
@@ -35,53 +30,39 @@ export default function Signin() {
   }, [authLevel, navigate]);
 
   return (
-    <PageContainer>
-      <MainLeftContainer>
-        <MainLeftBoxTop />
-        <MainLeftBoxBottom />
-      </MainLeftContainer>
-
-      <MainRightContainer>
-        <StyledSigninContainer>
-          <StyledLogoContainer>
-            <Logo />
-            <Text color="gray/gray900" size={16} lineHeight="lg">
-              우리끼리 만들어 더욱 강력한 <br />
-              전공 포트폴리오
+    <StyledSigninContainer>
+      <StyledLogoContainer>
+        <Logo />
+        <Text color="gray/gray900" size={16} lineHeight="lg">
+          우리끼리 만들어 더욱 강력한 <br />
+          전공 포트폴리오
+        </Text>
+      </StyledLogoContainer>
+      <StickyBottom>
+        <StyledButtonContainer>
+          <Button
+            category="outlined"
+            onClick={() => {
+              navigate('/home');
+            }}
+          >
+            <Text
+              color="main_color/blue_p"
+              weight="bold"
+              lineHeight="sm"
+              size={16}
+            >
+              게스트로 입장하기
             </Text>
-          </StyledLogoContainer>
-          <StickyBottom>
-            <StyledButtonContainer>
-              <Button
-                category="outlined"
-                onClick={() => {
-                  navigate('/home');
-                }}
-              >
-                <Text
-                  color="main_color/blue_p"
-                  weight="bold"
-                  lineHeight="sm"
-                  size={16}
-                >
-                  게스트로 입장하기
-                </Text>
-              </Button>
-              <StyledSigninButton category="kakaotalk" onClick={onKakaoSignin}>
-                <KakaoIcon />
-                <Text
-                  color="gray/black"
-                  weight="bold"
-                  lineHeight="sm"
-                  size={16}
-                >
-                  카카오톡으로 시작하기
-                </Text>
-              </StyledSigninButton>
-            </StyledButtonContainer>
-          </StickyBottom>
-        </StyledSigninContainer>
-      </MainRightContainer>
-    </PageContainer>
+          </Button>
+          <StyledSigninButton category="kakaotalk" onClick={onKakaoSignin}>
+            <KakaoIcon />
+            <Text color="gray/black" weight="bold" lineHeight="sm" size={16}>
+              카카오톡으로 시작하기
+            </Text>
+          </StyledSigninButton>
+        </StyledButtonContainer>
+      </StickyBottom>
+    </StyledSigninContainer>
   );
 }

--- a/src/pages/Upload/UploadGuidelineStep/index.tsx
+++ b/src/pages/Upload/UploadGuidelineStep/index.tsx
@@ -15,13 +15,6 @@ import {
 import UploadSection from '../../../components/common/UploadSection';
 import BottomButtonBar from '../../../components/common/BottomButtonBar';
 import { useNextStep } from '..';
-import {
-  MainLeftContainer,
-  MainRightContainer,
-  PageContainer,
-} from '../../../components/common/GlobalStyle/index.styles';
-import MainLeftBoxTop from '../../../components/common/MainLeftBoxTop';
-import MainLeftBoxBottom from '../../../components/common/MainLeftBoxBottom';
 
 interface UploadGuidelineStepType {
   onNext: () => void;
@@ -98,13 +91,11 @@ export default function UploadGuidelineStep() {
 
   return (
     <>
-      <PageContainer>
-        <StyledBodyContainer>
-          {description}
-          {checklist}
-          <UploadSection items={[notice]} />
-        </StyledBodyContainer>
-      </PageContainer>
+      <StyledBodyContainer>
+        {description}
+        {checklist}
+        <UploadSection items={[notice]} />
+      </StyledBodyContainer>
       <BottomButtonBar transitions={transitions} />
     </>
   );

--- a/src/pages/Upload/UploadInProgressStep/index.tsx
+++ b/src/pages/Upload/UploadInProgressStep/index.tsx
@@ -22,13 +22,6 @@ import Modal from '../../../components/common/Modal';
 import { useNextStep } from '..';
 import UploadRoutes from '../../index.types';
 import useRefreshPayload from '../../../hooks/common/useRefreshPayload';
-import {
-  MainLeftContainer,
-  MainRightContainer,
-  PageContainer,
-} from '../../../components/common/GlobalStyle/index.styles';
-import MainLeftBoxTop from '../../../components/common/MainLeftBoxTop';
-import MainLeftBoxBottom from '../../../components/common/MainLeftBoxBottom';
 
 interface IFile {
   url: string;
@@ -242,7 +235,7 @@ export default function UploadInProgresStep() {
   ];
 
   return (
-    <PageContainer>
+    <>
       <SomeContainer>
         <Description
           normalText="자세한 정보로"
@@ -264,6 +257,6 @@ export default function UploadInProgresStep() {
         onPrimaryAction={closePrimarily}
         onSecondaryAction={closeSecondarily}
       />
-    </PageContainer>
+    </>
   );
 }

--- a/src/pages/Upload/index.tsx
+++ b/src/pages/Upload/index.tsx
@@ -15,13 +15,6 @@ import {
 import Text from '../../components/common/Text';
 import UploadRoutes from '../index.types';
 import StyledPageContainer from './UploadDefaultStep/index.styles';
-import {
-  MainLeftContainer,
-  MainRightContainer,
-  PageContainer,
-} from '../../components/common/GlobalStyle/index.styles';
-import MainLeftBoxTop from '../../components/common/MainLeftBoxTop';
-import MainLeftBoxBottom from '../../components/common/MainLeftBoxBottom';
 
 type UploadContextType = {
   navigateToNextStep: () => void;
@@ -79,31 +72,24 @@ export default function Upload() {
       </button>
     );
   return (
-    <PageContainer>
-      <MainLeftContainer>
-        <MainLeftBoxTop />
-        <MainLeftBoxBottom />
-      </MainLeftContainer>
-
-      <MainRightContainer>
-        <SecondaryTopbar
-          transition={transitionButton}
-          title={
-            <Text size={18} weight="bold" lineHeight="sm" color="gray/gray900">
-              업로드
-            </Text>
+    <>
+      <SecondaryTopbar
+        transition={transitionButton}
+        title={
+          <Text size={18} weight="bold" lineHeight="sm" color="gray/gray900">
+            업로드
+          </Text>
+        }
+        icons={[]}
+      />
+      <StyledPageContainer>
+        <Outlet
+          context={
+            { navigateToNextStep, navigateToHome } satisfies UploadContextType
           }
-          icons={[]}
         />
-        <StyledPageContainer>
-          <Outlet
-            context={
-              { navigateToNextStep, navigateToHome } satisfies UploadContextType
-            }
-          />
-        </StyledPageContainer>
-      </MainRightContainer>
-    </PageContainer>
+      </StyledPageContainer>
+    </>
   );
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,11 +26,13 @@ import DeleteAccount from './My/DeleteAccount';
 import Bookmarks from './My/Bookmarks';
 import Likes from './My/Likes';
 import Transactions from './My/Transactions';
+import RootContainer from './RootContainer';
 
 const Router = () => {
   const router = createBrowserRouter([
     {
       path: '/',
+      element: <RootContainer />,
       children: [
         {
           index: true,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,6 +23,9 @@ import UploadCautionStep from './Upload/UploadCautionStep';
 import UploadCollectPhoneNumberStep from './Upload/UploadCollectPhoneNumberStep';
 import MyViewMore from './My/MyViewMore';
 import DeleteAccount from './My/DeleteAccount';
+import Bookmarks from './My/Bookmarks';
+import Likes from './My/Likes';
+import Transactions from './My/Transactions';
 
 const Router = () => {
   const router = createBrowserRouter([
@@ -110,6 +113,9 @@ const Router = () => {
             { path: 'view-more', element: <MyViewMore /> },
             { path: 'signout', element: <span /> },
             { path: 'delete-account', element: <DeleteAccount /> },
+            { path: 'bookmarks', element: <Bookmarks /> },
+            { path: 'likes', element: <Likes /> },
+            { path: 'transactions', element: <Transactions /> },
           ],
         },
       ],

--- a/src/stories/Bookmarks.stories.tsx
+++ b/src/stories/Bookmarks.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import Bookmarks from '../pages/My/Bookmarks';
+
+const meta = {
+  title: 'Bookmarks',
+  component: Bookmarks,
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/Likes.stories.tsx
+++ b/src/stories/Likes.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import Likes from '../pages/My/Likes';
+
+const meta = {
+  title: 'Likes',
+  component: Likes,
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/Transactions.stories.tsx
+++ b/src/stories/Transactions.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import Transactions from '../pages/My/Transactions';
+
+const meta = {
+  title: 'Transactions',
+  component: Transactions,
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
# Description

- [x] 모두보기 화면에서 페이지가 처음 로드된 뒤에 스크롤을 내려야 자료가 로드되던 버그를 수정했습니다
  - 기존: 스켈레톤 카드를 렌더링하고 끝까지 내려야 로딩
  - 현재: isLoading의 값이 false라 처음에 스켈레톤 UI가 나오지 않게 하여 즉시 컨텐츠가 로드되도록 수정
- [x] 2번째 페이지 로드부터는 스켈레톤 UI가 렌더링되지 않던 버그를 수정했습니다. 
  - 기존 allMaterials?.materialResponseList은 값은 첫번째 페이지 load 이후부터는 null아 아니라 스켈레톤 UI를 보여주지 않았습니다.
  - 현재: loading 상태를 통해 스켈레톤 UI 렌더링하도록 수정했습니다.

- [x] 북마크한 과제 모두보기 페이지 추가
  - [ ] 클릭 가능하게 해야 되는 건지? 클릭하게 되면 어디로 이동? 현재 백엔드 api 상에서는 과제 자세히보기를 할 수는 없다.
  - [ ] 현재 구현 에러: 학기를 임의로 표시하고 있음.
- [x] 좋아요한 과제 모두보기 페이지 추가
  - [ ] 클릭 가능하게 해야 되는 건지? 클릭하게 되면 어디로 이동? 현재 백엔드 api 상에서는 과제 자세히보기를 할 수는 없다.
  - [ ] 현재 구현 에러: 학기를 임의로 표시하고 있음.
- [x] 거래 내역 페이지 추가했으나, 아직 과제 조회는 안 됩니다.

