### PR TITLE
Fix/render transactions in another tab

### DIFF
--- a/src/hooks/common/useRefreshPayload/index.ts
+++ b/src/hooks/common/useRefreshPayload/index.ts
@@ -9,6 +9,10 @@ export default function useRefreshPayload() {
   const navigate = useNavigate();
 
   const onRetrySuccess = (newAccessToken: string, newRefreshToken: string) => {
+    if (!newAccessToken || !newRefreshToken) {
+      alert(newAccessToken);
+      alert(newRefreshToken);
+    }
     refresh(newAccessToken, newRefreshToken);
   };
 

--- a/src/pages/My/Transactions/index.tsx
+++ b/src/pages/My/Transactions/index.tsx
@@ -162,6 +162,7 @@ export default function Transactions() {
       onItemClick={(index) => setSelectedTab(index)}
     />
   );
+  console.log(selectedTab);
 
   const cardSection = (
     <>

--- a/src/pages/My/Transactions/index.tsx
+++ b/src/pages/My/Transactions/index.tsx
@@ -24,6 +24,7 @@ import useTransactions, {
 import HomeMaterialCardSkeleton from '../../../components/home/HomeMaterialCardSkeleton';
 import StyledPageContainer from '../../Upload/UploadDefaultStep/index.styles';
 import StyledRow from '../ContactUs/index.styles';
+import { getPurchases, getSales } from '../../../apis/payment';
 
 type TransactionCardPropsType = {
   category: SaleKeys | PurchaseKeys;
@@ -130,13 +131,16 @@ export function TransactionCard({
 
 export default function Transactions() {
   const {
-    isLoading,
-    purchases,
-    sales,
-    selectedTab,
-    setSelectedTab,
-    bottomRef,
-  } = useTransactions();
+    isLoading: isSaleLoading,
+    transactions: sales,
+    bottomRef: salesBottomRef,
+  } = useTransactions(getSales);
+  const {
+    isLoading: isPurchaseLoading,
+    transactions: purchases,
+    bottomRef: purchasesBottomRef,
+  } = useTransactions(getPurchases);
+  const [selectedTab, setSelectedTab] = useState<number>(0);
 
   const navigate = useNavigate();
 
@@ -162,7 +166,6 @@ export default function Transactions() {
       onItemClick={(index) => setSelectedTab(index)}
     />
   );
-  console.log(selectedTab);
 
   const cardSection = (
     <>
@@ -232,7 +235,7 @@ export default function Transactions() {
     </>
   );
 
-  const skeletonCardSection = isLoading && (
+  const skeletonCardSection = (
     <CardsWrapper>
       <HomeMaterialCardSkeleton isBig={false} />
       <HomeMaterialCardSkeleton isBig={false} />
@@ -248,8 +251,14 @@ export default function Transactions() {
       <StyledPageContainer>
         {tabBar}
         {cardSection}
-        {skeletonCardSection}
-        <div ref={bottomRef} style={{ height: '10px' }} />
+        {selectedTab === 0 && isPurchaseLoading && skeletonCardSection}
+        {selectedTab === 1 && isSaleLoading && skeletonCardSection}
+        {selectedTab === 0 && (
+          <div ref={purchasesBottomRef} style={{ height: '10px' }} />
+        )}
+        {selectedTab === 1 && (
+          <div ref={salesBottomRef} style={{ height: '10px' }} />
+        )}
       </StyledPageContainer>
     </>
   );

--- a/src/pages/My/Transactions/useTransactions/index.ts
+++ b/src/pages/My/Transactions/useTransactions/index.ts
@@ -24,14 +24,6 @@ export type PurchaseKeys =
 export type PurchasesType = Partial<
   Record<PurchaseKeys, TransactionMaterial[]>
 >;
-// {
-//   beforePay?: TransactionMaterial[];
-//   beforeRefund?: TransactionMaterial[];
-//   afterPay?: TransactionMaterial[];
-//   isDown?: TransactionMaterial[];
-//   cancel?: TransactionMaterial[];
-//   afterRefund?: TransactionMaterial[];
-// };
 
 export type SaleKeys = 'pending' | 'complete';
 

--- a/src/pages/My/Transactions/useTransactions/index.ts
+++ b/src/pages/My/Transactions/useTransactions/index.ts
@@ -48,7 +48,6 @@ export default function useTransactions() {
   const {
     isLoading,
     nextPage,
-    hasLastPageReached,
     bottomRef,
     canLoadMore,
     startLoading,
@@ -68,8 +67,7 @@ export default function useTransactions() {
           accessToken,
           refreshPayload,
         );
-        console.log(data);
-        if (data.status === 404) {
+        if (data.code === 3000 || data.code === 8001) {
           finishLoading();
           reachLastPage();
           return;
@@ -100,7 +98,7 @@ export default function useTransactions() {
         }));
       } else {
         const data = await getSales(nextPage, 10, accessToken, refreshPayload);
-        if (data.code === 8001) {
+        if (data.code === 3000 || data.code === 8001) {
           return;
         }
         const newSales: SalesType = data;
@@ -136,13 +134,13 @@ export default function useTransactions() {
       observer.disconnect();
     };
   }, [
-    isLoading,
-    hasLastPageReached,
     canLoadMore,
     nextPage,
     startLoading,
     finishLoading,
     reachLastPage,
+    accessToken,
+    refreshPayload,
     sales,
     purchases,
     selectedTab,


### PR DESCRIPTION
# Description

- [x] 거래 내역 탭 별로 조회되지 않던 문제 해결
  - [x] useTransaction hook 두개를 사용하여 거래 내역과 구매 내역을 각각 관리