### PR TITLE
fix: use wrong state and update function

### DIFF
--- a/src/pages/Upload/UploadInProgressStep/index.tsx
+++ b/src/pages/Upload/UploadInProgressStep/index.tsx
@@ -354,9 +354,9 @@ export default function UploadInProgresStep() {
           'NP',
           'P',
         ]}
-        searchQuery={score}
-        onSearchQueryUpdate={(newScore) => {
-          updateDraft({ score: newScore });
+        searchQuery={grade}
+        onSearchQueryUpdate={(newGrade) => {
+          updateDraft({ grade: newGrade });
           setHasScoreError(false);
         }}
         icon={hasScoreError ? <ErrorDefaultIcon /> : <span />}


### PR DESCRIPTION
# Description


- [x] 4. 주의사항 및 자료환불 조건
- [x] 5. My > 쿠폰함
- [x] 7. 업로드 > 전화번호 입력 취소시 업로드입력 페이지 나가짐
- [x] 8. 업로드 > 전화번호 입력 취소시 업로드입력 페이지 나가짐
- [x] 10. 업로드 > 가이드라인 부분 타이틀 오류
- [x] 11. 업로드 > 가이드라인 > 주의사항 링크연결
- [x] 12. My > 거래내역(구매, 결제) 헤더타이틀 없음
- [x] 13. My > 거래내역 자료금액 표시에 콤마 및 '원' 없음
- [x] 15. 송금안내페이지 > 구매취소시 My > 구매내역으로 보냄
- [x] 20. 상세페이지 좋아요, 북마크 버튼
- [x] 학점 타이핑시 성적에 같이 타이핑 되는 문제 해결
 